### PR TITLE
allows superview as 2nd view outside a current view hierarchy 

### DIFF
--- a/TABSwiftLayout/Constraint.swift
+++ b/TABSwiftLayout/Constraint.swift
@@ -251,7 +251,8 @@ public struct Constraint: ConstraintDefinition {
   public weak var secondView: View? {
     didSet {
       if let view = secondView {
-        precondition(view.superview != nil, "The second view MUST be inserted into a superview before constraints can be applied")
+        let hasSuperViewOrIsSuperView = view.superview != nil || firstView.superview == view
+        precondition(hasSuperViewOrIsSuperView, "The second view MUST be inserted into a superview before constraints can be applied OR it MUST be the superview of the first view")
       }
     }
   }

--- a/TABSwiftLayout/Constraint.swift
+++ b/TABSwiftLayout/Constraint.swift
@@ -248,14 +248,7 @@ public struct Constraint: ConstraintDefinition {
     }
   }
   
-  public weak var secondView: View? {
-    didSet {
-      if let view = secondView {
-        let hasSuperViewOrIsSuperView = view.superview != nil || firstView.superview == view
-        precondition(hasSuperViewOrIsSuperView, "The second view MUST be inserted into a superview before constraints can be applied OR it MUST be the superview of the first view")
-      }
-    }
-  }
+  public weak var secondView: View?
   
   private weak var _constraint: NSLayoutConstraint?
   


### PR DESCRIPTION
previously if you tried to pin a view to it's superview _before_ that superview had been added to another view (i.e. during init) then this would fail on the precondition. 

this new approach gets around that
