### PR TITLE
added macOS alias for the OSX platform which was added in Swift 3

### DIFF
--- a/Sources/Constraint.swift
+++ b/Sources/Constraint.swift
@@ -23,7 +23,7 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if os(OSX)
+#if os(macOS)
   import AppKit
   public typealias View = NSView
   public typealias LayoutPriority = NSLayoutPriority


### PR DESCRIPTION
more details here -

[https://github.com/apple/swift-evolution/blob/master/proposals/0106-rename-osx-to-macos.md](url)