### PR TITLE
Set priority on constraint

### DIFF
--- a/Sources/Constraint.swift
+++ b/Sources/Constraint.swift
@@ -274,7 +274,7 @@ public struct Constraint: ConstraintDefinition {
         attribute: self.secondAttribute,
         multiplier: self.multiplier,
         constant: self.constant)
-        self._constraint?.priority = self.priority
+      self._constraint?.priority = self.priority
     }
     
     return self._constraint!

--- a/Sources/Constraint.swift
+++ b/Sources/Constraint.swift
@@ -274,6 +274,7 @@ public struct Constraint: ConstraintDefinition {
         attribute: self.secondAttribute,
         multiplier: self.multiplier,
         constant: self.constant)
+        self._constraint?.priority = self.priority
     }
     
     return self._constraint!


### PR DESCRIPTION
Previously the priority would always be required (1000) despite setting in the pin/align/etc methods