### PR TITLE
Add units tests, 66% coverage

### DIFF
--- a/TABSwiftLayout.xcodeproj/project.pbxproj
+++ b/TABSwiftLayout.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		395175FC1D7DA1FF0077541C /* LayoutDefines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395175F61D7DA1060077541C /* LayoutDefines.swift */; };
 		395175FD1D7DA34E0077541C /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395175F41D7DA1060077541C /* Constraint.swift */; };
 		399583281D88534200BCC40E /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399583271D88534200BCC40E /* Deprecations.swift */; };
+		AB03825A20CEAB7800762187 /* TABSwiftLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 395175E91D7DA0F00077541C /* TABSwiftLayout.framework */; };
+		AB03826320CEABB100762187 /* LayoutDefinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03826020CEABB000762187 /* LayoutDefinesTests.swift */; };
+		AB03826420CEABB100762187 /* ConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03826120CEABB100762187 /* ConstraintTests.swift */; };
+		AB03826520CEABB100762187 /* LayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03826220CEABB100762187 /* LayoutTests.swift */; };
 		AB0CD2FB1FED38D900992DFA /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399583271D88534200BCC40E /* Deprecations.swift */; };
 		AB0CD2FC1FED38D900992DFA /* Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395175F51D7DA1060077541C /* Layout.swift */; };
 		AB0CD2FD1FED38D900992DFA /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395175F41D7DA1060077541C /* Constraint.swift */; };
@@ -21,6 +25,16 @@
 		AB0CD3021FED3A0E00992DFA /* PlatformDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CD3001FED3A0E00992DFA /* PlatformDefinitions.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		AB03825B20CEAB7800762187 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 395175E01D7DA0F00077541C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 395175E81D7DA0F00077541C;
+			remoteInfo = TABSwiftLayout;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		395175E91D7DA0F00077541C /* TABSwiftLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TABSwiftLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		395175EC1D7DA0F00077541C /* TABSwiftLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TABSwiftLayout.h; sourceTree = "<group>"; };
@@ -29,6 +43,11 @@
 		395175F51D7DA1060077541C /* Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Layout.swift; sourceTree = "<group>"; };
 		395175F61D7DA1060077541C /* LayoutDefines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutDefines.swift; sourceTree = "<group>"; };
 		399583271D88534200BCC40E /* Deprecations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
+		AB03825520CEAB7800762187 /* TABSwiftLayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TABSwiftLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB03825920CEAB7800762187 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB03826020CEABB000762187 /* LayoutDefinesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutDefinesTests.swift; sourceTree = "<group>"; };
+		AB03826120CEABB100762187 /* ConstraintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintTests.swift; sourceTree = "<group>"; };
+		AB03826220CEABB100762187 /* LayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutTests.swift; sourceTree = "<group>"; };
 		AB0CD2F31FED38D000992DFA /* TABSwiftLayoutMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TABSwiftLayoutMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB0CD3001FED3A0E00992DFA /* PlatformDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformDefinitions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -38,6 +57,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AB03825220CEAB7800762187 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB03825A20CEAB7800762187 /* TABSwiftLayout.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				395175FB1D7DA1A60077541C /* Metadata */,
+				AB03825620CEAB7800762187 /* TABSwiftLayoutTests */,
 				395175EA1D7DA0F00077541C /* Products */,
 				395175FA1D7DA1940077541C /* Sources */,
 			);
@@ -65,6 +93,7 @@
 			children = (
 				395175E91D7DA0F00077541C /* TABSwiftLayout.framework */,
 				AB0CD2F31FED38D000992DFA /* TABSwiftLayoutMac.framework */,
+				AB03825520CEAB7800762187 /* TABSwiftLayoutTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -88,6 +117,17 @@
 				395175EC1D7DA0F00077541C /* TABSwiftLayout.h */,
 			);
 			path = Metadata;
+			sourceTree = "<group>";
+		};
+		AB03825620CEAB7800762187 /* TABSwiftLayoutTests */ = {
+			isa = PBXGroup;
+			children = (
+				AB03826120CEABB100762187 /* ConstraintTests.swift */,
+				AB03826020CEABB000762187 /* LayoutDefinesTests.swift */,
+				AB03826220CEABB100762187 /* LayoutTests.swift */,
+				AB03825920CEAB7800762187 /* Info.plist */,
+			);
+			path = TABSwiftLayoutTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -130,6 +170,24 @@
 			productReference = 395175E91D7DA0F00077541C /* TABSwiftLayout.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		AB03825420CEAB7800762187 /* TABSwiftLayoutTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AB03825F20CEAB7800762187 /* Build configuration list for PBXNativeTarget "TABSwiftLayoutTests" */;
+			buildPhases = (
+				AB03825120CEAB7800762187 /* Sources */,
+				AB03825220CEAB7800762187 /* Frameworks */,
+				AB03825320CEAB7800762187 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AB03825C20CEAB7800762187 /* PBXTargetDependency */,
+			);
+			name = TABSwiftLayoutTests;
+			productName = TABSwiftLayoutTests;
+			productReference = AB03825520CEAB7800762187 /* TABSwiftLayoutTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		AB0CD2F21FED38D000992DFA /* TABSwiftLayoutMac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AB0CD2F81FED38D100992DFA /* Build configuration list for PBXNativeTarget "TABSwiftLayoutMac" */;
@@ -154,12 +212,17 @@
 		395175E01D7DA0F00077541C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0910;
 				ORGANIZATIONNAME = TheAppBusiness;
 				TargetAttributes = {
 					395175E81D7DA0F00077541C = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
+					};
+					AB03825420CEAB7800762187 = {
+						CreatedOnToolsVersion = 9.3;
+						ProvisioningStyle = Automatic;
 					};
 					AB0CD2F21FED38D000992DFA = {
 						CreatedOnToolsVersion = 9.1;
@@ -181,12 +244,20 @@
 			targets = (
 				395175E81D7DA0F00077541C /* TABSwiftLayout */,
 				AB0CD2F21FED38D000992DFA /* TABSwiftLayoutMac */,
+				AB03825420CEAB7800762187 /* TABSwiftLayoutTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		395175E71D7DA0F00077541C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AB03825320CEAB7800762187 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -215,6 +286,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AB03825120CEAB7800762187 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB03826320CEABB100762187 /* LayoutDefinesTests.swift in Sources */,
+				AB03826520CEABB100762187 /* LayoutTests.swift in Sources */,
+				AB03826420CEABB100762187 /* ConstraintTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AB0CD2EE1FED38D000992DFA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -228,6 +309,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AB03825C20CEAB7800762187 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 395175E81D7DA0F00077541C /* TABSwiftLayout */;
+			targetProxy = AB03825B20CEAB7800762187 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		395175EF1D7DA0F00077541C /* Debug */ = {
@@ -377,6 +466,53 @@
 			};
 			name = Release;
 		};
+		AB03825D20CEAB7800762187 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TABSwiftLayoutTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = TheAppBusiness.TABSwiftLayoutTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AB03825E20CEAB7800762187 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TABSwiftLayoutTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = TheAppBusiness.TABSwiftLayoutTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		AB0CD2F91FED38D100992DFA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -455,6 +591,15 @@
 			buildConfigurations = (
 				395175F21D7DA0F00077541C /* Debug */,
 				395175F31D7DA0F00077541C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AB03825F20CEAB7800762187 /* Build configuration list for PBXNativeTarget "TABSwiftLayoutTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB03825D20CEAB7800762187 /* Debug */,
+				AB03825E20CEAB7800762187 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TABSwiftLayout.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TABSwiftLayout.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TABSwiftLayout.xcodeproj/xcshareddata/xcschemes/TABSwiftLayout.xcscheme
+++ b/TABSwiftLayout.xcodeproj/xcshareddata/xcschemes/TABSwiftLayout.xcscheme
@@ -26,10 +26,29 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB03825420CEAB7800762187"
+               BuildableName = "TABSwiftLayoutTests.xctest"
+               BlueprintName = "TABSwiftLayoutTests"
+               ReferencedContainer = "container:TABSwiftLayout.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "395175E81D7DA0F00077541C"
+            BuildableName = "TABSwiftLayout.framework"
+            BlueprintName = "TABSwiftLayout"
+            ReferencedContainer = "container:TABSwiftLayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -37,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/TABSwiftLayoutTests/ConstraintTests.swift
+++ b/TABSwiftLayoutTests/ConstraintTests.swift
@@ -1,0 +1,33 @@
+//
+//  ConstraintTests.swift
+//  TABSwiftLayoutTests
+//
+//  Created by Jonathan on 29/12/2017.
+//  Copyright © 2017 TheAppBusiness. All rights reserved.
+//
+
+import XCTest
+
+class ConstraintTests: XCTestCase {
+  
+  private func simpleConstraint(view: UIView = UIView(), attribute: NSLayoutAttribute) -> NSLayoutConstraint {
+    return NSLayoutConstraint(item: view, attribute: attribute, relatedBy: .equal, toItem: UIView(), attribute: attribute, multiplier: 1, constant: 0)
+  }
+  
+  func testConstraintTrait() {
+    XCTAssertEqual(simpleConstraint(attribute: .top).trait, .TopMargin)
+    XCTAssertEqual(simpleConstraint(attribute: .left).trait, .LeftMargin)
+    XCTAssertEqual(simpleConstraint(attribute: .leading).trait, .LeftMargin)
+    XCTAssertEqual(simpleConstraint(attribute: .right).trait, .RightMargin)
+    XCTAssertEqual(simpleConstraint(attribute: .trailing).trait, .RightMargin)
+    XCTAssertEqual(simpleConstraint(attribute: .bottom).trait, .BottomMargin)
+    
+    XCTAssertEqual(simpleConstraint(attribute: .centerX).trait, .HorizontalAlignment)
+    XCTAssertEqual(simpleConstraint(attribute: .centerY).trait, .VerticalAlignment)
+    
+    XCTAssertEqual(simpleConstraint(attribute: .width).trait, .HorizontalSizing)
+    XCTAssertEqual(simpleConstraint(attribute: .height).trait, .VerticalSizing)
+    
+    XCTAssertEqual(simpleConstraint(attribute: .lastBaseline).trait, .None)
+  }
+}

--- a/TABSwiftLayoutTests/Info.plist
+++ b/TABSwiftLayoutTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TABSwiftLayoutTests/LayoutDefinesTests.swift
+++ b/TABSwiftLayoutTests/LayoutDefinesTests.swift
@@ -1,0 +1,86 @@
+//
+//  LayoutDefinesTests.swift
+//  LayoutDefinesTests
+//
+//  Created by Jonathan on 29/12/2017.
+//  Copyright © 2017 TheAppBusiness. All rights reserved.
+//
+
+import XCTest
+@testable import TABSwiftLayout
+
+class LayoutDefinesTests: XCTestCase {
+  
+  func testSameEdgeMasksAreSame() {
+    XCTAssertEqual(EdgeMask.top, .top)
+    XCTAssertEqual(EdgeMask.left, .left)
+    XCTAssertEqual(EdgeMask.bottom, .bottom)
+    XCTAssertEqual(EdgeMask.right, .right)
+  }
+  
+  func testDifferentEdgeMasksAreDifferent() {
+    XCTAssertNotEqual(EdgeMask.top, .left)
+    XCTAssertNotEqual(EdgeMask.top, .bottom)
+    XCTAssertNotEqual(EdgeMask.top, .right)
+    
+    XCTAssertNotEqual(EdgeMask.left, .top)
+    XCTAssertNotEqual(EdgeMask.left, .bottom)
+    XCTAssertNotEqual(EdgeMask.left, .right)
+    
+    XCTAssertNotEqual(EdgeMask.bottom, .top)
+    XCTAssertNotEqual(EdgeMask.bottom, .left)
+    XCTAssertNotEqual(EdgeMask.bottom, .right)
+    
+    XCTAssertNotEqual(EdgeMask.right, .top)
+    XCTAssertNotEqual(EdgeMask.right, .left)
+    XCTAssertNotEqual(EdgeMask.right, .bottom)
+  }
+  
+  func testEdgeMasksCombinedEdges() {
+    XCTAssertEqual(EdgeMask.leftAndRight, [.left, .right])
+    XCTAssertEqual(EdgeMask.topAndBottom, [.top, .bottom])
+    XCTAssertEqual(EdgeMask.all, EdgeMask.leftAndRight.union(.topAndBottom))
+  }
+  
+  func testEdgeMarginsDefaultInit() {
+    let margins = EdgeMargins()
+    XCTAssertEqual(margins.top, 0)
+    XCTAssertEqual(margins.left, 0)
+    XCTAssertEqual(margins.bottom, 0)
+    XCTAssertEqual(margins.right, 0)
+  }
+  
+  func testEdgeMarginsAllInit() {
+    let margins = EdgeMargins(all: 5)
+    XCTAssertEqual(margins.top, 5)
+    XCTAssertEqual(margins.bottom, 5)
+    XCTAssertEqual(margins.left, 5)
+    XCTAssertEqual(margins.right, 5)
+  }
+  
+  func testEdgeMarginsStandardInit() {
+    let margins = EdgeMargins(top: 1, left: 2, bottom: 3, right: 4)
+    XCTAssertEqual(margins.top, 1)
+    XCTAssertEqual(margins.left, 2)
+    XCTAssertEqual(margins.bottom, 3)
+    XCTAssertEqual(margins.right, 4)
+  }
+  
+  
+  func testSizeAttributeConversion() {
+    XCTAssertEqual(sizeAttribute(axis: .horizontal), .width)
+    XCTAssertEqual(sizeAttribute(axis: .vertical), .height)
+  }
+  
+  func testCenterAttributeConversion() {
+    XCTAssertEqual(centerAttribute(axis: .horizontal), .centerX)
+    XCTAssertEqual(centerAttribute(axis: .vertical), .centerY)
+  }
+  
+  func testEdgeAttributeConversion() {
+    XCTAssertEqual(edgeAttribute(edge: .top), .top)
+    XCTAssertEqual(edgeAttribute(edge: .left), .left)
+    XCTAssertEqual(edgeAttribute(edge: .bottom), .bottom)
+    XCTAssertEqual(edgeAttribute(edge: .right), .right)
+  }
+}

--- a/TABSwiftLayoutTests/LayoutTests.swift
+++ b/TABSwiftLayoutTests/LayoutTests.swift
@@ -1,0 +1,270 @@
+//
+//  LayoutTests.swift
+//  TABSwiftLayoutTests
+//
+//  Created by Jonathan on 29/12/2017.
+//  Copyright © 2017 TheAppBusiness. All rights reserved.
+//
+
+import XCTest
+@testable import TABSwiftLayout
+
+class LayoutTests: XCTestCase {
+  
+  private let testPriority = LayoutPriority(rawValue: 751)
+  
+  private func simpleViewHierarchy() -> (UIView, UIView) {
+    let superview = UIView()
+    let subview = UIView()
+    superview.addSubview(subview)
+    return (superview, subview)
+  }
+  
+  func testPinEdges() {
+    let (sv, v) = simpleViewHierarchy()
+    let constraints = v.pin(edges: .all, toView: sv, relation: .equal, margins: EdgeMargins(top: 1, left: 2, bottom: 3, right: 4), priority: testPriority)
+    XCTAssertEqual(constraints.count, 4)
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .top && $0.constant == 1 })
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .left && $0.constant == 2 })
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .bottom && $0.constant == -3 })
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .right && $0.constant == -4 })
+    constraints.forEach {
+      XCTAssertTrue($0.isActive)
+      XCTAssertEqual($0.firstItem as? UIView, v)
+      XCTAssertEqual($0.secondItem as? UIView, sv)
+      XCTAssertEqual($0.relation, .equal)
+      XCTAssertEqual($0.priority, testPriority)
+    }
+    XCTAssertEqual(sv.constraints, constraints)
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testPinEdge() {
+    let (sv, v) = simpleViewHierarchy()
+    let constraint = v.pin(edge: .top, toEdge: .bottom, ofView: sv, relation: .greaterThanOrEqual, margin: 20, priority: testPriority)
+    XCTAssertEqual(constraint.firstAttribute, .top)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .bottom)
+    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.relation, .greaterThanOrEqual)
+    //it is minus 20 because +20 would be 20 beyond (below) the sv bottom
+    XCTAssertEqual(constraint.constant, -20)
+    XCTAssertEqual(constraint.multiplier, 1)
+    XCTAssertEqual(constraint.priority, testPriority)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(sv.constraints, [constraint])
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testAlignAxis() {
+    let (sv, v) = simpleViewHierarchy()
+    let constraint = v.align(axis: .horizontal, relativeTo: sv, offset: 20, priority: testPriority)
+    XCTAssertEqual(constraint.firstAttribute, .centerX)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .centerX)
+    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.relation, .equal)
+    XCTAssertEqual(constraint.constant, 20)
+    XCTAssertEqual(constraint.multiplier, 1)
+    XCTAssertEqual(constraint.priority, testPriority)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(sv.constraints, [constraint])
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testSizeAxisOfViews() {
+    let (sv, v1) = simpleViewHierarchy()
+    let v2 = UIView()
+    sv.addSubview(v2)
+    
+    let constraints = sv.size(axis: .horizontal, ofViews: [v1, v2], ratio: 0.5, priority: testPriority)
+    
+    XCTAssertEqual(constraints.count, 2)
+    XCTAssertTrue(constraints.contains { $0.firstItem as? UIView == v1 })
+    XCTAssertTrue(constraints.contains { $0.firstItem as? UIView == v2 })
+    constraints.forEach {
+      XCTAssertTrue($0.isActive)
+      XCTAssertEqual($0.secondItem as? UIView, sv)
+      XCTAssertEqual($0.firstAttribute, .width)
+      XCTAssertEqual($0.secondAttribute, .width)
+      XCTAssertEqual($0.relation, .equal)
+      XCTAssertEqual($0.multiplier, 0.5)
+      XCTAssertEqual($0.constant, 0)
+      XCTAssertEqual($0.priority, testPriority)
+    }
+    XCTAssertEqual(sv.constraints, constraints)
+    XCTAssertEqual(v1.constraints.count, 0)
+    XCTAssertEqual(v2.constraints.count, 0)
+  }
+  
+  func testSizeAxisToConstant() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraint = v.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
+    
+    XCTAssertEqual(constraint.firstAttribute, .height)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .notAnAttribute)
+    XCTAssertEqual(constraint.secondItem as? UIView, nil)
+    XCTAssertEqual(constraint.constant, 200)
+    XCTAssertEqual(constraint.multiplier, 1)
+    XCTAssertEqual(constraint.relation, .equal)
+    XCTAssertEqual(constraint.priority, testPriority)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(v.constraints, [constraint])
+    XCTAssertEqual(sv.constraints.count, 0)
+  }
+  
+  func testSizeAxisRelativeToOtherAxis() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraint = v.size(axis: .vertical, relativeTo: .horizontal, ofView: v, ratio: 0.5, priority: testPriority)
+    
+    XCTAssertEqual(constraint.firstAttribute, .height)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .width)
+    XCTAssertEqual(constraint.secondItem as? UIView, v)
+    XCTAssertEqual(constraint.constant, 0)
+    XCTAssertEqual(constraint.multiplier, 0.5)
+    XCTAssertEqual(constraint.relation, .equal)
+    XCTAssertEqual(constraint.priority, testPriority)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(v.constraints, [constraint])
+    XCTAssertEqual(sv.constraints.count, 0)
+  }
+  
+  func testSizeBothAxisToConstant() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraints = v.size(width: 200, height: 300, relation: .greaterThanOrEqual, priority: testPriority)
+    
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .width && $0.constant == 200 })
+    XCTAssertTrue(constraints.contains { $0.firstAttribute == .height && $0.constant == 300 })
+    constraints.forEach {
+      XCTAssertEqual($0.firstItem as? UIView, v)
+      XCTAssertEqual($0.secondAttribute, .notAnAttribute)
+      XCTAssertEqual($0.secondItem as? UIView, nil)
+      XCTAssertEqual($0.multiplier, 1)
+      XCTAssertEqual($0.relation, .greaterThanOrEqual)
+      XCTAssertEqual($0.priority, testPriority)
+      XCTAssertTrue($0.isActive)
+    }
+    XCTAssertEqual(v.constraints, constraints)
+    XCTAssertEqual(sv.constraints.count, 0)
+  }
+  
+  func testAlignEdgesToView() {
+    var edges: [NSLayoutAttribute] = [.top, .bottom, .left, .right]
+    
+    while edges.count > 0 {
+      let edgeMask: EdgeMask = edges.reduce(into: EdgeMask(rawValue: 0)) { (result, next) in
+        switch next {
+        case .left:
+          result.insert(.left)
+        case .right:
+          result.insert(.right)
+        case .top:
+          result.insert(.top)
+        case .bottom:
+          result.insert(.bottom)
+        default:
+          XCTFail()
+        }
+      }
+      let (sv, v) = simpleViewHierarchy()
+      
+      v.align(edges: edgeMask, toView: sv)
+      
+      let constraints = sv.constraints
+      for edge in edges {
+        XCTAssertTrue(constraints.contains { $0.firstAttribute == edge && $0.secondAttribute == edge})
+      }
+      constraints.forEach {
+        XCTAssertEqual($0.firstItem as? UIView, v)
+        XCTAssertEqual($0.secondItem as? UIView, sv)
+        XCTAssertEqual($0.constant, 0)
+        XCTAssertEqual($0.multiplier, 1)
+        XCTAssertEqual($0.relation, .equal)
+        XCTAssertEqual($0.priority, .required)
+        XCTAssertTrue($0.isActive)
+      }
+      
+      XCTAssertEqual(v.constraints.count, 0)
+      _ = edges.popLast()
+    }
+  }
+  
+  
+  func testAlignHorizontally() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraint = v.alignHorizontally(toView: sv)
+    
+    XCTAssertEqual(constraint.firstAttribute, .centerX)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .centerX)
+    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.constant, 0)
+    XCTAssertEqual(constraint.multiplier, 1)
+    XCTAssertEqual(constraint.relation, .equal)
+    XCTAssertEqual(constraint.priority, .required)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(sv.constraints, [constraint])
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testAlignVertically() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraint = v.alignVertically(toView: sv)
+    
+    XCTAssertEqual(constraint.firstAttribute, .centerY)
+    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.secondAttribute, .centerY)
+    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.constant, 0)
+    XCTAssertEqual(constraint.multiplier, 1)
+    XCTAssertEqual(constraint.relation, .equal)
+    XCTAssertEqual(constraint.priority, .required)
+    XCTAssertTrue(constraint.isActive)
+    
+    XCTAssertEqual(sv.constraints, [constraint])
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testResetConstraints() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let constraint = v.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
+    
+    XCTAssertEqual(v.constraints, [constraint])
+    XCTAssertEqual(sv.constraints.count, 0)
+    
+    v.resetConstraints()
+    
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+  func testResetSubViewConstraints() {
+    let (sv, v) = simpleViewHierarchy()
+    
+    let sizeConstraint = sv.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
+    
+    var allConstraints = v.pin(edges: .all, toView: sv)
+    allConstraints.append(sizeConstraint)
+    
+    XCTAssertEqual(Set(sv.constraints), Set(allConstraints))
+    XCTAssertEqual(v.constraints.count, 0)
+    
+    sv.resetSubViewConstraints()
+    
+    XCTAssertEqual(sv.constraints, [sizeConstraint])
+    XCTAssertEqual(v.constraints.count, 0)
+  }
+  
+}

--- a/TABSwiftLayoutTests/LayoutTests.swift
+++ b/TABSwiftLayoutTests/LayoutTests.swift
@@ -11,7 +11,11 @@ import XCTest
 
 class LayoutTests: XCTestCase {
   
-  private let testPriority = LayoutPriority(rawValue: 751)
+  private var testPriority: LayoutPriority!
+  
+  override func setUp() {
+    testPriority = LayoutPriority(Float(arc4random_uniform(1001)))
+  }
   
   private func simpleViewHierarchy() -> (UIView, UIView) {
     let superview = UIView()

--- a/TABSwiftLayoutTests/LayoutTests.swift
+++ b/TABSwiftLayoutTests/LayoutTests.swift
@@ -12,21 +12,19 @@ import XCTest
 class LayoutTests: XCTestCase {
   
   private var testPriority: LayoutPriority!
+  private var superview: UIView!
+  private var view: UIView!
+  
   
   override func setUp() {
     testPriority = LayoutPriority(Float(arc4random_uniform(1001)))
-  }
-  
-  private func simpleViewHierarchy() -> (UIView, UIView) {
-    let superview = UIView()
-    let subview = UIView()
-    superview.addSubview(subview)
-    return (superview, subview)
+    superview = UIView()
+    view = UIView()
+    superview.addSubview(view)
   }
   
   func testPinEdges() {
-    let (sv, v) = simpleViewHierarchy()
-    let constraints = v.pin(edges: .all, toView: sv, relation: .equal, margins: EdgeMargins(top: 1, left: 2, bottom: 3, right: 4), priority: testPriority)
+    let constraints = view.pin(edges: .all, toView: superview, relation: .equal, margins: EdgeMargins(top: 1, left: 2, bottom: 3, right: 4), priority: testPriority)
     XCTAssertEqual(constraints.count, 4)
     XCTAssertTrue(constraints.contains { $0.firstAttribute == .top && $0.constant == 1 })
     XCTAssertTrue(constraints.contains { $0.firstAttribute == .left && $0.constant == 2 })
@@ -34,22 +32,21 @@ class LayoutTests: XCTestCase {
     XCTAssertTrue(constraints.contains { $0.firstAttribute == .right && $0.constant == -4 })
     constraints.forEach {
       XCTAssertTrue($0.isActive)
-      XCTAssertEqual($0.firstItem as? UIView, v)
-      XCTAssertEqual($0.secondItem as? UIView, sv)
+      XCTAssertEqual($0.firstItem as? UIView, view)
+      XCTAssertEqual($0.secondItem as? UIView, superview)
       XCTAssertEqual($0.relation, .equal)
       XCTAssertEqual($0.priority, testPriority)
     }
-    XCTAssertEqual(sv.constraints, constraints)
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, constraints)
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testPinEdge() {
-    let (sv, v) = simpleViewHierarchy()
-    let constraint = v.pin(edge: .top, toEdge: .bottom, ofView: sv, relation: .greaterThanOrEqual, margin: 20, priority: testPriority)
+    let constraint = view.pin(edge: .top, toEdge: .bottom, ofView: superview, relation: .greaterThanOrEqual, margin: 20, priority: testPriority)
     XCTAssertEqual(constraint.firstAttribute, .top)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .bottom)
-    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.secondItem as? UIView, superview)
     XCTAssertEqual(constraint.relation, .greaterThanOrEqual)
     //it is minus 20 because +20 would be 20 beyond (below) the sv bottom
     XCTAssertEqual(constraint.constant, -20)
@@ -57,40 +54,39 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(constraint.priority, testPriority)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(sv.constraints, [constraint])
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, [constraint])
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testAlignAxis() {
-    let (sv, v) = simpleViewHierarchy()
-    let constraint = v.align(axis: .horizontal, relativeTo: sv, offset: 20, priority: testPriority)
+    let constraint = view.align(axis: .horizontal, relativeTo: superview, offset: 20, priority: testPriority)
     XCTAssertEqual(constraint.firstAttribute, .centerX)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .centerX)
-    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.secondItem as? UIView, superview)
     XCTAssertEqual(constraint.relation, .equal)
     XCTAssertEqual(constraint.constant, 20)
     XCTAssertEqual(constraint.multiplier, 1)
     XCTAssertEqual(constraint.priority, testPriority)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(sv.constraints, [constraint])
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, [constraint])
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testSizeAxisOfViews() {
-    let (sv, v1) = simpleViewHierarchy()
+    let v1: UIView! = view
     let v2 = UIView()
-    sv.addSubview(v2)
+    superview.addSubview(v2)
     
-    let constraints = sv.size(axis: .horizontal, ofViews: [v1, v2], ratio: 0.5, priority: testPriority)
+    let constraints = superview.size(axis: .horizontal, ofViews: [v1, v2], ratio: 0.5, priority: testPriority)
     
     XCTAssertEqual(constraints.count, 2)
     XCTAssertTrue(constraints.contains { $0.firstItem as? UIView == v1 })
     XCTAssertTrue(constraints.contains { $0.firstItem as? UIView == v2 })
     constraints.forEach {
       XCTAssertTrue($0.isActive)
-      XCTAssertEqual($0.secondItem as? UIView, sv)
+      XCTAssertEqual($0.secondItem as? UIView, superview)
       XCTAssertEqual($0.firstAttribute, .width)
       XCTAssertEqual($0.secondAttribute, .width)
       XCTAssertEqual($0.relation, .equal)
@@ -98,18 +94,16 @@ class LayoutTests: XCTestCase {
       XCTAssertEqual($0.constant, 0)
       XCTAssertEqual($0.priority, testPriority)
     }
-    XCTAssertEqual(sv.constraints, constraints)
+    XCTAssertEqual(superview.constraints, constraints)
     XCTAssertEqual(v1.constraints.count, 0)
     XCTAssertEqual(v2.constraints.count, 0)
   }
   
   func testSizeAxisToConstant() {
-    let (sv, v) = simpleViewHierarchy()
-    
-    let constraint = v.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
+    let constraint = view.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
     
     XCTAssertEqual(constraint.firstAttribute, .height)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .notAnAttribute)
     XCTAssertEqual(constraint.secondItem as? UIView, nil)
     XCTAssertEqual(constraint.constant, 200)
@@ -118,38 +112,34 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(constraint.priority, testPriority)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(v.constraints, [constraint])
-    XCTAssertEqual(sv.constraints.count, 0)
+    XCTAssertEqual(view.constraints, [constraint])
+    XCTAssertEqual(superview.constraints.count, 0)
   }
   
   func testSizeAxisRelativeToOtherAxis() {
-    let (sv, v) = simpleViewHierarchy()
-    
-    let constraint = v.size(axis: .vertical, relativeTo: .horizontal, ofView: v, ratio: 0.5, priority: testPriority)
+    let constraint = view.size(axis: .vertical, relativeTo: .horizontal, ofView: view, ratio: 0.5, priority: testPriority)
     
     XCTAssertEqual(constraint.firstAttribute, .height)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .width)
-    XCTAssertEqual(constraint.secondItem as? UIView, v)
+    XCTAssertEqual(constraint.secondItem as? UIView, view)
     XCTAssertEqual(constraint.constant, 0)
     XCTAssertEqual(constraint.multiplier, 0.5)
     XCTAssertEqual(constraint.relation, .equal)
     XCTAssertEqual(constraint.priority, testPriority)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(v.constraints, [constraint])
-    XCTAssertEqual(sv.constraints.count, 0)
+    XCTAssertEqual(view.constraints, [constraint])
+    XCTAssertEqual(superview.constraints.count, 0)
   }
   
   func testSizeBothAxisToConstant() {
-    let (sv, v) = simpleViewHierarchy()
-    
-    let constraints = v.size(width: 200, height: 300, relation: .greaterThanOrEqual, priority: testPriority)
+    let constraints = view.size(width: 200, height: 300, relation: .greaterThanOrEqual, priority: testPriority)
     
     XCTAssertTrue(constraints.contains { $0.firstAttribute == .width && $0.constant == 200 })
     XCTAssertTrue(constraints.contains { $0.firstAttribute == .height && $0.constant == 300 })
     constraints.forEach {
-      XCTAssertEqual($0.firstItem as? UIView, v)
+      XCTAssertEqual($0.firstItem as? UIView, view)
       XCTAssertEqual($0.secondAttribute, .notAnAttribute)
       XCTAssertEqual($0.secondItem as? UIView, nil)
       XCTAssertEqual($0.multiplier, 1)
@@ -157,8 +147,8 @@ class LayoutTests: XCTestCase {
       XCTAssertEqual($0.priority, testPriority)
       XCTAssertTrue($0.isActive)
     }
-    XCTAssertEqual(v.constraints, constraints)
-    XCTAssertEqual(sv.constraints.count, 0)
+    XCTAssertEqual(view.constraints, constraints)
+    XCTAssertEqual(superview.constraints.count, 0)
   }
   
   func testAlignEdgesToView() {
@@ -179,17 +169,15 @@ class LayoutTests: XCTestCase {
           XCTFail()
         }
       }
-      let (sv, v) = simpleViewHierarchy()
+      view.align(edges: edgeMask, toView: superview)
       
-      v.align(edges: edgeMask, toView: sv)
-      
-      let constraints = sv.constraints
+      let constraints = superview.constraints
       for edge in edges {
         XCTAssertTrue(constraints.contains { $0.firstAttribute == edge && $0.secondAttribute == edge})
       }
       constraints.forEach {
-        XCTAssertEqual($0.firstItem as? UIView, v)
-        XCTAssertEqual($0.secondItem as? UIView, sv)
+        XCTAssertEqual($0.firstItem as? UIView, view)
+        XCTAssertEqual($0.secondItem as? UIView, superview)
         XCTAssertEqual($0.constant, 0)
         XCTAssertEqual($0.multiplier, 1)
         XCTAssertEqual($0.relation, .equal)
@@ -197,78 +185,70 @@ class LayoutTests: XCTestCase {
         XCTAssertTrue($0.isActive)
       }
       
-      XCTAssertEqual(v.constraints.count, 0)
+      XCTAssertEqual(view.constraints.count, 0)
       _ = edges.popLast()
     }
   }
   
   
   func testAlignHorizontally() {
-    let (sv, v) = simpleViewHierarchy()
-    
-    let constraint = v.alignHorizontally(toView: sv)
+    let constraint = view.alignHorizontally(toView: superview)
     
     XCTAssertEqual(constraint.firstAttribute, .centerX)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .centerX)
-    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.secondItem as? UIView, superview)
     XCTAssertEqual(constraint.constant, 0)
     XCTAssertEqual(constraint.multiplier, 1)
     XCTAssertEqual(constraint.relation, .equal)
     XCTAssertEqual(constraint.priority, .required)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(sv.constraints, [constraint])
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, [constraint])
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testAlignVertically() {
-    let (sv, v) = simpleViewHierarchy()
-    
-    let constraint = v.alignVertically(toView: sv)
+    let constraint = view.alignVertically(toView: superview)
     
     XCTAssertEqual(constraint.firstAttribute, .centerY)
-    XCTAssertEqual(constraint.firstItem as? UIView, v)
+    XCTAssertEqual(constraint.firstItem as? UIView, view)
     XCTAssertEqual(constraint.secondAttribute, .centerY)
-    XCTAssertEqual(constraint.secondItem as? UIView, sv)
+    XCTAssertEqual(constraint.secondItem as? UIView, superview)
     XCTAssertEqual(constraint.constant, 0)
     XCTAssertEqual(constraint.multiplier, 1)
     XCTAssertEqual(constraint.relation, .equal)
     XCTAssertEqual(constraint.priority, .required)
     XCTAssertTrue(constraint.isActive)
     
-    XCTAssertEqual(sv.constraints, [constraint])
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, [constraint])
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testResetConstraints() {
-    let (sv, v) = simpleViewHierarchy()
+    let constraint = view.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
     
-    let constraint = v.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
+    XCTAssertEqual(view.constraints, [constraint])
+    XCTAssertEqual(superview.constraints.count, 0)
     
-    XCTAssertEqual(v.constraints, [constraint])
-    XCTAssertEqual(sv.constraints.count, 0)
+    view.resetConstraints()
     
-    v.resetConstraints()
-    
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
   func testResetSubViewConstraints() {
-    let (sv, v) = simpleViewHierarchy()
+    let sizeConstraint = superview.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
     
-    let sizeConstraint = sv.size(axis: .vertical, relatedBy: .equal, size: 200, priority: testPriority)
-    
-    var allConstraints = v.pin(edges: .all, toView: sv)
+    var allConstraints = view.pin(edges: .all, toView: superview)
     allConstraints.append(sizeConstraint)
     
-    XCTAssertEqual(Set(sv.constraints), Set(allConstraints))
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(Set(superview.constraints), Set(allConstraints))
+    XCTAssertEqual(view.constraints.count, 0)
     
-    sv.resetSubViewConstraints()
+    superview.resetSubViewConstraints()
     
-    XCTAssertEqual(sv.constraints, [sizeConstraint])
-    XCTAssertEqual(v.constraints.count, 0)
+    XCTAssertEqual(superview.constraints, [sizeConstraint])
+    XCTAssertEqual(view.constraints.count, 0)
   }
   
 }


### PR DESCRIPTION
Wrote these a while ago and forgot about them as I kept thinking I'll do a PR when the coverage is 100%. But already the merge conflict was too difficult, that it was easier to recreate the test targets and add the files, in a new commit.

Having the unit tests would've caught this bug (https://github.com/theappbusiness/TABSwiftLayout/pull/15)  also it will allow changes without risk of breaking things, as this could do with some refactoring.